### PR TITLE
Fixing wrong comparison for implicit related relations.

### DIFF
--- a/board-viewer.html
+++ b/board-viewer.html
@@ -1256,7 +1256,7 @@ Polymer({
       if (related) {
         for (var i = 0; i < related.length; i++) {
           if (relatedRefdes.related.indexOf(related[i]) == -1 &&
-            currentState.refdes != connected[i]){
+            currentState.refdes != related[i]){
             relatedRefdes.related.push(related[i]);
           }
         }


### PR DESCRIPTION
This fix part of issue: https://github.com/Board-Explorer/board-viewer/issues/20, related components was still adding references to themselves due a bad comparison.