### PR TITLE
fixing typo in filter name

### DIFF
--- a/board-viewer.html
+++ b/board-viewer.html
@@ -1644,7 +1644,7 @@ Polymer({
       var filters = [];
       for (var i = 0; i < this._filters.length; i++) {
         if (this._filters[i].name.indexOf("connected-") == 0 ||
-            this._filters[i].name.indexOf("highlit-") == 0 ||
+            this._filters[i].name.indexOf("highlight-") == 0 ||
             this._filters[i].name.indexOf("related-") == 0) {
           filters.push(this._filters[i].name);
         }


### PR DESCRIPTION
This PR fix the string to find in filters from "highlit" to "highlight"